### PR TITLE
fix: correctly parse VIP info from keepalive.data

### DIFF
--- a/internal/collector/parser.go
+++ b/internal/collector/parser.go
@@ -132,7 +132,10 @@ func ParseVRRPData(i io.Reader) (map[string]*VRRPData, error) {
 				if err := data[instance].setVRID(val); err != nil {
 					return data, err
 				}
-			case "Virtual IP":
+			}
+			// Newer versions can write "Virtual IP (1):" instead of
+			// "Virtual IP :" in the keepalive.data file.
+			if strings.Contains(key, "Virtual IP") && val != "" {
 				data[instance].addVIP(val)
 			}
 		} else if strings.HasPrefix(l, " VRRP Version") || strings.HasPrefix(l, " VRRP Script") {

--- a/internal/collector/parser_test.go
+++ b/internal/collector/parser_test.go
@@ -85,6 +85,69 @@ func TestVRRPDataStringToIntState(t *testing.T) {
 	}
 }
 
+func TestV227ParseVRRPData(t *testing.T) {
+	f, err := os.Open("../../test_files/v2.2.7/keepalived.data")
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+	defer f.Close()
+
+	vrrpData, err := ParseVRRPData(f)
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+	if len(vrrpData) != 3 {
+		t.Fail()
+	}
+
+	viExt1 := VRRPData{
+		IName:     "VI_EXT_1",
+		State:     2,
+		WantState: 2,
+		Intf:      "ens192",
+		GArpDelay: 5,
+		VRID:      10,
+		VIPs:      []string{"192.168.2.1 dev ens192 scope global set"},
+	}
+	viExt2 := VRRPData{
+		IName:     "VI_EXT_2",
+		State:     1,
+		WantState: 1,
+		Intf:      "ens192",
+		GArpDelay: 5,
+		VRID:      20,
+		VIPs:      []string{"192.168.2.2 dev ens192 scope global"},
+	}
+	viExt3 := VRRPData{
+		IName:     "VI_EXT_3",
+		State:     1,
+		WantState: 1,
+		Intf:      "ens192",
+		GArpDelay: 5,
+		VRID:      30,
+		VIPs:      []string{"192.168.2.3 dev ens192 scope global"},
+	}
+
+	for _, data := range vrrpData {
+		if data.IName == "VI_EXT_1" {
+			if !reflect.DeepEqual(*data, viExt1) {
+				t.Fail()
+			}
+		} else if data.IName == "VI_EXT_2" {
+			if !reflect.DeepEqual(*data, viExt2) {
+				t.Fail()
+			}
+		} else if data.IName == "VI_EXT_3" {
+			if !reflect.DeepEqual(*data, viExt3) {
+				t.Fail()
+			}
+		}
+	}
+}
+
 func TestV215ParseVRRPData(t *testing.T) {
 	f, err := os.Open("../../test_files/v2.1.5/keepalived.data")
 	if err != nil {

--- a/test_files/v2.2.7/keepalived.data
+++ b/test_files/v2.2.7/keepalived.data
@@ -1,0 +1,151 @@
+------< VRRP Topology >------
+ VRRP Instance = VI_EXT_1
+   VRRP Version = 2
+   State = MASTER
+   Wantstate = MASTER
+   Number of interface and track script faults = 0
+   Number of track scripts init = 0
+   Last transition = 1594831166.420598 (Wed Jul 15 21:09:26 2020.420598)
+   Read timeout = 1594995529.942882 (Fri Jul 17 18:48:49.942882)
+   Master down timer = 608848 usecs
+   Interface = ens192
+   Using src_ip = 192.168.1.1 (from configuration)
+   Gratuitous ARP delay = 5
+   Gratuitous ARP repeat = 5
+   Gratuitous ARP refresh = 0
+   Gratuitous ARP refresh repeat = 1
+   Gratuitous ARP lower priority delay = 5
+   Gratuitous ARP lower priority repeat = 5
+   Send advert after receive lower priority advert = true
+   Send advert after receive higher priority advert = false
+   Virtual Router ID = 10
+   Priority = 100
+   Effective priority = 100
+   Total priority = 100
+   Advert interval = 1 sec
+   Accept = enabled
+   Preempt = enabled
+   Promote_secondaries = disabled
+   Authentication type = SIMPLE_PASSWORD
+   Password = bacbefe5
+   Virtual IP (1):
+     192.168.2.1 dev ens192 scope global set
+   Unicast TTL = 255
+   Check unicast src : no
+   Unicast Peer :
+     192.168.1.2 min_ttl 0 max_ttl 255
+     192.168.1.3 min_ttl 0 max_ttl 255
+   Unicast checksum compatibility = no
+   fd_in 12, fd_out 13
+   Tracked scripts :
+     check_script weight -60
+   Using smtp notification = no
+   Notify deleted = Fault
+   Notify priority changes = false
+ VRRP Instance = VI_EXT_2
+   VRRP Version = 2
+   State = BACKUP
+   Master router = 192.168.1.2
+   Master priority = 100
+   Wantstate = BACKUP
+   Number of interface and track script faults = 0
+   Number of track scripts init = 0
+   Last transition = 1594974363.398961 (Fri Jul 17 12:56:03 2020.398961)
+   Read timeout = 1594995532.225480 (Fri Jul 17 18:48:52.225480)
+   Master down timer = 3687500 usecs
+   Interface = ens192
+   Using src_ip = 192.168.1.1 (from configuration)
+   Gratuitous ARP delay = 5
+   Gratuitous ARP repeat = 5
+   Gratuitous ARP refresh = 0
+   Gratuitous ARP refresh repeat = 1
+   Gratuitous ARP lower priority delay = 5
+   Gratuitous ARP lower priority repeat = 5
+   Send advert after receive lower priority advert = true
+   Send advert after receive higher priority advert = false
+   Virtual Router ID = 20
+   Priority = 80
+   Effective priority = 80
+   Total priority = 80
+   Advert interval = 1 sec
+   Accept = enabled
+   Preempt = enabled
+   Promote_secondaries = disabled
+   Authentication type = SIMPLE_PASSWORD
+   Password = password
+   Virtual IP (1):
+     192.168.2.2 dev ens192 scope global
+   Unicast TTL = 255
+   Check unicast src : no
+   Unicast Peer :
+     192.168.1.2 min_ttl 0 max_ttl 255
+     192.168.1.3 min_ttl 0 max_ttl 255
+   Unicast checksum compatibility = no
+   fd_in 12, fd_out 13
+   Tracked scripts :
+     check_script weight -60
+   Using smtp notification = no
+   Notify deleted = Fault
+   Notify priority changes = false
+ VRRP Instance = VI_EXT_3
+   VRRP Version = 2
+   State = BACKUP
+   Master router = 192.168.1.3
+   Master priority = 100
+   Wantstate = BACKUP
+   Number of interface and track script faults = 0
+   Number of track scripts init = 0
+   Last transition = 1594974363.374509 (Fri Jul 17 12:56:03 2020.374509)
+   Read timeout = 1594995532.381775 (Fri Jul 17 18:48:52.381775)
+   Master down timer = 3648437 usecs
+   Interface = ens192
+   Using src_ip = 192.168.1.1 (from configuration)
+   Gratuitous ARP delay = 5
+   Gratuitous ARP repeat = 5
+   Gratuitous ARP refresh = 0
+   Gratuitous ARP refresh repeat = 1
+   Gratuitous ARP lower priority delay = 5
+   Gratuitous ARP lower priority repeat = 5
+   Send advert after receive lower priority advert = true
+   Send advert after receive higher priority advert = false
+   Virtual Router ID = 30
+   Priority = 90
+   Effective priority = 90
+   Total priority = 90
+   Advert interval = 1 sec
+   Accept = enabled
+   Preempt = enabled
+   Promote_secondaries = disabled
+   Authentication type = SIMPLE_PASSWORD
+   Password = password
+   Virtual IP (1):
+     192.168.2.3 dev ens192 scope global
+   Unicast TTL = 255
+   Check unicast src : no
+   Unicast Peer :
+     192.168.1.2 min_ttl 0 max_ttl 255
+     192.168.1.3 min_ttl 0 max_ttl 255
+   Unicast checksum compatibility = no
+   fd_in 12, fd_out 13
+   Tracked scripts :
+     check_script weight -60
+   Using smtp notification = no
+   Notify deleted = Fault
+   Notify priority changes = false
+------< VRRP Scripts >------
+ VRRP Script = check_script
+   Command = '/etc/keepalived/script.sh'
+   Interval = 2 sec
+   Timeout = 0 sec
+   Weight = -60
+   Rise = 5
+   Fall = 1
+   Insecure = no
+   Status = GOOD
+   Script uid:gid = 0:0
+   VRRP instances :
+   Tracking instances :
+     VI_EXT_1, weight -60
+     VI_EXT_2, weight -60
+     VI_EXT_3, weight -60
+   State = idle

--- a/test_files/v2.2.7/keepalived.stats
+++ b/test_files/v2.2.7/keepalived.stats
@@ -1,0 +1,57 @@
+VRRP Instance: VI_EXT_1
+  Advertisements:
+    Received: 11
+    Sent: 12
+  Became master: 2
+  Released master: 1
+  Packet Errors:
+    Length: 1
+    TTL: 1
+    Invalid Type: 1
+    Advertisement Interval: 1
+    Address List: 1
+  Authentication Errors:
+    Invalid Type: 2
+    Type Mismatch: 2
+    Failure: 2
+  Priority Zero:
+    Received: 1
+    Sent: 1
+VRRP Instance: VI_EXT_2
+  Advertisements:
+    Received: 10
+    Sent: 158
+  Became master: 2
+  Released master: 2
+  Packet Errors:
+    Length: 10
+    TTL: 10
+    Invalid Type: 10
+    Advertisement Interval: 10
+    Address List: 10
+  Authentication Errors:
+    Invalid Type: 20
+    Type Mismatch: 20
+    Failure: 20
+  Priority Zero:
+    Received: 12
+    Sent: 12
+VRRP Instance: VI_EXT_3
+  Advertisements:
+    Received: 23
+    Sent: 172
+  Became master: 4
+  Released master: 4
+  Packet Errors:
+    Length: 30
+    TTL: 30
+    Invalid Type: 30
+    Advertisement Interval: 30
+    Address List: 30
+  Authentication Errors:
+    Invalid Type: 10
+    Type Mismatch: 10
+    Failure: 2
+  Priority Zero:
+    Received: 1
+    Sent: 2


### PR DESCRIPTION
Previously the key always was "Virtual IP :", but now with https://github.com/acassen/keepalived/commit/8e0371a1598e4669213a73d40c20e1e378a5b7e3 it is like "Virtual IP (1):". This change was introduced with version 2.2.5.

Without this fix, keepalived-exporter fails to gather the labels for `keepalived_vrrp_state` and that metric is then missing.