### PR TITLE
fix: adapt parsing logic for keepalived v2.2.7

### DIFF
--- a/internal/collector/parser.go
+++ b/internal/collector/parser.go
@@ -113,6 +113,9 @@ func ParseVRRPData(i io.Reader) (map[string]*VRRPData, error) {
 				}
 				val = strings.TrimSpace(args[1])
 			}
+			if (strings.HasPrefix(key, "Virtual IP (") || key == "Virtual IP") && val != "" {
+				data[instance].addVIP(val)
+			}
 			switch key {
 			case "State":
 				if err := data[instance].setState(val); err != nil {
@@ -132,8 +135,6 @@ func ParseVRRPData(i io.Reader) (map[string]*VRRPData, error) {
 				if err := data[instance].setVRID(val); err != nil {
 					return data, err
 				}
-			case "Virtual IP":
-				data[instance].addVIP(val)
 			}
 		} else if strings.HasPrefix(l, " VRRP Version") || strings.HasPrefix(l, " VRRP Script") {
 			// Seen in version <= 1.3.5

--- a/internal/collector/parser_test.go
+++ b/internal/collector/parser_test.go
@@ -467,3 +467,40 @@ func TestIsKeyArray(t *testing.T) {
 		t.Fail()
 	}
 }
+
+func TestV227ParseVRRPData(t *testing.T) {
+	f, err := os.Open("../../test_files/v2.2.7/keepalived.data")
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+	defer f.Close()
+
+	vrrpData, err := ParseVRRPData(f)
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+	if len(vrrpData) != 1 {
+		t.Fail()
+	}
+
+	viExt1 := VRRPData{
+		IName:     "VI_1",
+		State:     2,
+		WantState: 2,
+		Intf:      "ens3",
+		GArpDelay: 5,
+		VRID:      52,
+		VIPs:      []string{"10.1.0.1/24 dev ens3 scope global set"},
+	}
+
+	for _, data := range vrrpData {
+		if data.IName == "VI_1" {
+			if !reflect.DeepEqual(*data, viExt1) {
+				t.Fail()
+			}
+		}
+	}
+}

--- a/test_files/v2.2.7/keepalived.data
+++ b/test_files/v2.2.7/keepalived.data
@@ -1,0 +1,58 @@
+------< VRRP Topology >------
+ VRRP Instance = VI_1
+   VRRP Version = 3
+   State = MASTER
+   Flags: none
+   Wantstate = MASTER
+   Number of config faults = 0
+   Number of interface and track script faults = 0
+   Number of track scripts init = 0
+   Last transition = 1673674892.348360 (Sat Jan 14 06:41:32.348360 2023)
+   Read timeout = 1674563074.242128 (Tue Jan 24 13:24:34.242128 2023)
+   Master down timer = 1656250 usecs
+   Interface = ens3
+   Using src_ip = 10.1.0.166
+   Multicast address 224.0.0.18
+   Gratuitous ARP delay = 5
+   Gratuitous ARP repeat = 5
+   Gratuitous ARP refresh = 0
+   Gratuitous ARP refresh repeat = 1
+   Gratuitous ARP lower priority delay = 5
+   Gratuitous ARP lower priority repeat = 5
+   Down timer adverts = 3
+   Send advert after receive lower priority advert = true
+   Send advert after receive higher priority advert = false
+   Virtual Router ID = 52
+   Priority = 50
+   Effective priority = 150
+   Total priority = 150
+   Advert interval = 4000 milli-sec
+   Accept = enabled
+   Preempt = enabled
+   Promote_secondaries = disabled
+   Virtual IP (1):
+     10.1.0.1/24 dev ens3 scope global set
+   fd_in 14, fd_out 15
+   Tracked scripts :
+     chk_script weight 100
+   Using smtp notification = no
+   Notify deleted = Fault
+   Generic state transition script = '/etc/keepalived/script.sh', uid:gid 0:0
+   Notify priority changes = false
+------< VRRP Scripts >------
+ VRRP Script = check_script
+   Command = '/etc/keepalived/script.sh'
+   Interval = 2 sec
+   Timeout = 0 sec
+   Weight = 100
+   Rise = 1
+   Fall = 1
+   Result = 1
+   Insecure = no
+   Init state = unknown
+   Status = GOOD
+   Script uid:gid = 0:0
+   VRRP instances :
+   Tracking instances :
+     VI_1, weight 100
+   State = idle


### PR DESCRIPTION
might fix https://github.com/mehdy/keepalived-exporter/issues/84

I noticed this on a recent keepalived 2.2.7 version where no `keepalived_vrrp_state` was being reported.

looks like the format has been updated to reflect a count along with `Virtual IP` string, see https://github.com/acassen/keepalived/commit/8e0371a1598e4669213a73d40c20e1e378a5b7e3#diff-0223680d17d787f6b86e04dc2f561503d4e8331d7e5f494ec98fb397733ea285L736

please review.