### PR TITLE
fix: drop state label from metrics

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -126,28 +126,21 @@ func (k *KeepalivedCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 
 	for _, vrrp := range keepalivedStats.VRRPs {
-		state := ""
-		ok := false
-
-		if state, ok = vrrp.Data.getStringState(); !ok {
-			logrus.WithField("state", vrrp.Data.State).Warn("Unknown State found for vrrp: ", vrrp.Data.IName)
-		}
-
-		k.newConstMetric(ch, "keepalived_advertisements_received_total", prometheus.CounterValue, float64(vrrp.Stats.AdvertRcvd), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID), state)
-		k.newConstMetric(ch, "keepalived_advertisements_sent_total", prometheus.CounterValue, float64(vrrp.Stats.AdvertSent), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID), state)
-		k.newConstMetric(ch, "keepalived_become_master_total", prometheus.CounterValue, float64(vrrp.Stats.BecomeMaster), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID), state)
-		k.newConstMetric(ch, "keepalived_release_master_total", prometheus.CounterValue, float64(vrrp.Stats.ReleaseMaster), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID), state)
-		k.newConstMetric(ch, "keepalived_packet_length_errors_total", prometheus.CounterValue, float64(vrrp.Stats.PacketLenErr), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID), state)
-		k.newConstMetric(ch, "keepalived_advertisements_interval_errors_total", prometheus.CounterValue, float64(vrrp.Stats.AdvertIntervalErr), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID), state)
-		k.newConstMetric(ch, "keepalived_ip_ttl_errors_total", prometheus.CounterValue, float64(vrrp.Stats.IPTTLErr), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID), state)
-		k.newConstMetric(ch, "keepalived_invalid_type_received_total", prometheus.CounterValue, float64(vrrp.Stats.InvalidTypeRcvd), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID), state)
-		k.newConstMetric(ch, "keepalived_address_list_errors_total", prometheus.CounterValue, float64(vrrp.Stats.AddrListErr), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID), state)
-		k.newConstMetric(ch, "keepalived_authentication_invalid_total", prometheus.CounterValue, float64(vrrp.Stats.InvalidAuthType), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID), state)
-		k.newConstMetric(ch, "keepalived_authentication_mismatch_total", prometheus.CounterValue, float64(vrrp.Stats.AuthTypeMismatch), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID), state)
-		k.newConstMetric(ch, "keepalived_authentication_failure_total", prometheus.CounterValue, float64(vrrp.Stats.AuthFailure), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID), state)
-		k.newConstMetric(ch, "keepalived_priority_zero_received_total", prometheus.CounterValue, float64(vrrp.Stats.PRIZeroRcvd), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID), state)
-		k.newConstMetric(ch, "keepalived_priority_zero_sent_total", prometheus.CounterValue, float64(vrrp.Stats.PRIZeroSent), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID), state)
-		k.newConstMetric(ch, "keepalived_gratuitous_arp_delay_total", prometheus.CounterValue, float64(vrrp.Data.GArpDelay), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID), state)
+		k.newConstMetric(ch, "keepalived_advertisements_received_total", prometheus.CounterValue, float64(vrrp.Stats.AdvertRcvd), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID))
+		k.newConstMetric(ch, "keepalived_advertisements_sent_total", prometheus.CounterValue, float64(vrrp.Stats.AdvertSent), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID))
+		k.newConstMetric(ch, "keepalived_become_master_total", prometheus.CounterValue, float64(vrrp.Stats.BecomeMaster), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID))
+		k.newConstMetric(ch, "keepalived_release_master_total", prometheus.CounterValue, float64(vrrp.Stats.ReleaseMaster), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID))
+		k.newConstMetric(ch, "keepalived_packet_length_errors_total", prometheus.CounterValue, float64(vrrp.Stats.PacketLenErr), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID))
+		k.newConstMetric(ch, "keepalived_advertisements_interval_errors_total", prometheus.CounterValue, float64(vrrp.Stats.AdvertIntervalErr), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID))
+		k.newConstMetric(ch, "keepalived_ip_ttl_errors_total", prometheus.CounterValue, float64(vrrp.Stats.IPTTLErr), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID))
+		k.newConstMetric(ch, "keepalived_invalid_type_received_total", prometheus.CounterValue, float64(vrrp.Stats.InvalidTypeRcvd), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID))
+		k.newConstMetric(ch, "keepalived_address_list_errors_total", prometheus.CounterValue, float64(vrrp.Stats.AddrListErr), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID))
+		k.newConstMetric(ch, "keepalived_authentication_invalid_total", prometheus.CounterValue, float64(vrrp.Stats.InvalidAuthType), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID))
+		k.newConstMetric(ch, "keepalived_authentication_mismatch_total", prometheus.CounterValue, float64(vrrp.Stats.AuthTypeMismatch), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID))
+		k.newConstMetric(ch, "keepalived_authentication_failure_total", prometheus.CounterValue, float64(vrrp.Stats.AuthFailure), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID))
+		k.newConstMetric(ch, "keepalived_priority_zero_received_total", prometheus.CounterValue, float64(vrrp.Stats.PRIZeroRcvd), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID))
+		k.newConstMetric(ch, "keepalived_priority_zero_sent_total", prometheus.CounterValue, float64(vrrp.Stats.PRIZeroSent), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID))
+		k.newConstMetric(ch, "keepalived_gratuitous_arp_delay_total", prometheus.CounterValue, float64(vrrp.Data.GArpDelay), vrrp.Data.IName, vrrp.Data.Intf, strconv.Itoa(vrrp.Data.VRID))
 
 		for _, ip := range vrrp.Data.VIPs {
 			ipAddr, intf, ok := ParseVIP(ip)
@@ -262,7 +255,7 @@ func (k *KeepalivedCollector) Describe(ch chan<- *prometheus.Desc) {
 }
 
 func (k *KeepalivedCollector) fillMetrics() {
-	commonLabels := []string{"iname", "intf", "vrid", "state"}
+	commonLabels := []string{"iname", "intf", "vrid"}
 	k.metrics = map[string]*prometheus.Desc{
 		"keepalived_up":                                   prometheus.NewDesc("keepalived_up", "Status", nil, nil),
 		"keepalived_vrrp_state":                           prometheus.NewDesc("keepalived_vrrp_state", "State of vrrp", []string{"iname", "intf", "vrid", "ip_address"}, nil),

--- a/internal/collector/collector_test.go
+++ b/internal/collector/collector_test.go
@@ -16,7 +16,7 @@ func TestNewConstMetric(t *testing.T) {
 		var valueType prometheus.ValueType
 
 		pm := make(chan prometheus.Metric, 1)
-		labelValues := []string{"iname", "intf", "vrid", "state"}
+		labelValues := []string{"iname", "intf", "vrid"}
 
 		switch metric {
 		case "keepalived_advertisements_received_total", "keepalived_advertisements_sent_total", "keepalived_become_master_total",
@@ -61,21 +61,21 @@ func TestFillMetrics(t *testing.T) {
 		"keepalived_up":                                   prometheus.NewDesc("keepalived_up", "Status", nil, nil),
 		"keepalived_vrrp_state":                           prometheus.NewDesc("keepalived_vrrp_state", "State of vrrp", []string{"iname", "intf", "vrid", "ip_address"}, nil),
 		"keepalived_exporter_check_script_status":         prometheus.NewDesc("keepalived_exporter_check_script_status", "Check Script status for each VIP", []string{"iname", "intf", "vrid", "ip_address"}, nil),
-		"keepalived_gratuitous_arp_delay_total":           prometheus.NewDesc("keepalived_gratuitous_arp_delay_total", "Gratuitous ARP delay", []string{"iname", "intf", "vrid", "state"}, nil),
-		"keepalived_advertisements_received_total":        prometheus.NewDesc("keepalived_advertisements_received_total", "Advertisements received", []string{"iname", "intf", "vrid", "state"}, nil),
-		"keepalived_advertisements_sent_total":            prometheus.NewDesc("keepalived_advertisements_sent_total", "Advertisements sent", []string{"iname", "intf", "vrid", "state"}, nil),
-		"keepalived_become_master_total":                  prometheus.NewDesc("keepalived_become_master_total", "Became master", []string{"iname", "intf", "vrid", "state"}, nil),
-		"keepalived_release_master_total":                 prometheus.NewDesc("keepalived_release_master_total", "Released master", []string{"iname", "intf", "vrid", "state"}, nil),
-		"keepalived_packet_length_errors_total":           prometheus.NewDesc("keepalived_packet_length_errors_total", "Packet length errors", []string{"iname", "intf", "vrid", "state"}, nil),
-		"keepalived_advertisements_interval_errors_total": prometheus.NewDesc("keepalived_advertisements_interval_errors_total", "Advertisement interval errors", []string{"iname", "intf", "vrid", "state"}, nil),
-		"keepalived_ip_ttl_errors_total":                  prometheus.NewDesc("keepalived_ip_ttl_errors_total", "TTL errors", []string{"iname", "intf", "vrid", "state"}, nil),
-		"keepalived_invalid_type_received_total":          prometheus.NewDesc("keepalived_invalid_type_received_total", "Invalid type errors", []string{"iname", "intf", "vrid", "state"}, nil),
-		"keepalived_address_list_errors_total":            prometheus.NewDesc("keepalived_address_list_errors_total", "Address list errors", []string{"iname", "intf", "vrid", "state"}, nil),
-		"keepalived_authentication_invalid_total":         prometheus.NewDesc("keepalived_authentication_invalid_total", "Authentication invalid", []string{"iname", "intf", "vrid", "state"}, nil),
-		"keepalived_authentication_mismatch_total":        prometheus.NewDesc("keepalived_authentication_mismatch_total", "Authentication mismatch", []string{"iname", "intf", "vrid", "state"}, nil),
-		"keepalived_authentication_failure_total":         prometheus.NewDesc("keepalived_authentication_failure_total", "Authentication failure", []string{"iname", "intf", "vrid", "state"}, nil),
-		"keepalived_priority_zero_received_total":         prometheus.NewDesc("keepalived_priority_zero_received_total", "Priority zero received", []string{"iname", "intf", "vrid", "state"}, nil),
-		"keepalived_priority_zero_sent_total":             prometheus.NewDesc("keepalived_priority_zero_sent_total", "Priority zero sent", []string{"iname", "intf", "vrid", "state"}, nil),
+		"keepalived_gratuitous_arp_delay_total":           prometheus.NewDesc("keepalived_gratuitous_arp_delay_total", "Gratuitous ARP delay", []string{"iname", "intf", "vrid"}, nil),
+		"keepalived_advertisements_received_total":        prometheus.NewDesc("keepalived_advertisements_received_total", "Advertisements received", []string{"iname", "intf", "vrid"}, nil),
+		"keepalived_advertisements_sent_total":            prometheus.NewDesc("keepalived_advertisements_sent_total", "Advertisements sent", []string{"iname", "intf", "vrid"}, nil),
+		"keepalived_become_master_total":                  prometheus.NewDesc("keepalived_become_master_total", "Became master", []string{"iname", "intf", "vrid"}, nil),
+		"keepalived_release_master_total":                 prometheus.NewDesc("keepalived_release_master_total", "Released master", []string{"iname", "intf", "vrid"}, nil),
+		"keepalived_packet_length_errors_total":           prometheus.NewDesc("keepalived_packet_length_errors_total", "Packet length errors", []string{"iname", "intf", "vrid"}, nil),
+		"keepalived_advertisements_interval_errors_total": prometheus.NewDesc("keepalived_advertisements_interval_errors_total", "Advertisement interval errors", []string{"iname", "intf", "vrid"}, nil),
+		"keepalived_ip_ttl_errors_total":                  prometheus.NewDesc("keepalived_ip_ttl_errors_total", "TTL errors", []string{"iname", "intf", "vrid"}, nil),
+		"keepalived_invalid_type_received_total":          prometheus.NewDesc("keepalived_invalid_type_received_total", "Invalid type errors", []string{"iname", "intf", "vrid"}, nil),
+		"keepalived_address_list_errors_total":            prometheus.NewDesc("keepalived_address_list_errors_total", "Address list errors", []string{"iname", "intf", "vrid"}, nil),
+		"keepalived_authentication_invalid_total":         prometheus.NewDesc("keepalived_authentication_invalid_total", "Authentication invalid", []string{"iname", "intf", "vrid"}, nil),
+		"keepalived_authentication_mismatch_total":        prometheus.NewDesc("keepalived_authentication_mismatch_total", "Authentication mismatch", []string{"iname", "intf", "vrid"}, nil),
+		"keepalived_authentication_failure_total":         prometheus.NewDesc("keepalived_authentication_failure_total", "Authentication failure", []string{"iname", "intf", "vrid"}, nil),
+		"keepalived_priority_zero_received_total":         prometheus.NewDesc("keepalived_priority_zero_received_total", "Priority zero received", []string{"iname", "intf", "vrid"}, nil),
+		"keepalived_priority_zero_sent_total":             prometheus.NewDesc("keepalived_priority_zero_sent_total", "Priority zero sent", []string{"iname", "intf", "vrid"}, nil),
 		"keepalived_script_status":                        prometheus.NewDesc("keepalived_script_status", "Tracker Script Status", []string{"name"}, nil),
 		"keepalived_script_state":                         prometheus.NewDesc("keepalived_script_state", "Tracker Script State", []string{"name"}, nil),
 	}

--- a/internal/collector/parser.go
+++ b/internal/collector/parser.go
@@ -39,14 +39,6 @@ func (v *VRRPScript) getIntState() (int, bool) {
 	return -1, false
 }
 
-func (v *VRRPData) getStringState() (string, bool) {
-	if v.State < len(VRRPStates) && v.State >= 0 {
-		return VRRPStates[v.State], true
-	}
-
-	return "", false
-}
-
 func vrrpDataStringToIntState(state string) (int, bool) {
 	for i, s := range VRRPStates {
 		if s == state {

--- a/internal/collector/parser_test.go
+++ b/internal/collector/parser_test.go
@@ -44,30 +44,6 @@ func TestGetIntState(t *testing.T) {
 	}
 }
 
-func TestGetStringState(t *testing.T) {
-	t.Parallel()
-
-	acceptableStates := []string{"INIT", "BACKUP", "MASTER", "FAULT"}
-	data := VRRPData{}
-
-	for state, expected := range acceptableStates {
-		data.State = state
-		if result, ok := data.getStringState(); !ok || result != expected {
-			t.Fail()
-		}
-	}
-
-	data.State = -1
-	if result, ok := data.getStringState(); ok || result != "" {
-		t.Fail()
-	}
-
-	data.State = len(acceptableStates)
-	if result, ok := data.getStringState(); ok || result != "" {
-		t.Fail()
-	}
-}
-
 func TestVRRPDataStringToIntState(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
As the vrrp state would change from time to time, having it as a label will lead to introducing new metrics which isn't a good practice. It will also make duplicated metrics in grafana dashboard view which is unnecessary.

Signed-off-by: Seena Fallah <seenafallah@gmail.com>