### PR TITLE
feat: open the keepalived stats file with retry support

### DIFF
--- a/internal/types/container/keepalived_container_collector_host.go
+++ b/internal/types/container/keepalived_container_collector_host.go
@@ -131,7 +131,7 @@ func (k *KeepalivedContainerCollectorHost) JSONVrrps() ([]collector.VRRP, error)
 		return nil, err
 	}
 
-	f, err := os.Open(k.jsonPath)
+	f, err := utils.OpenFileWithRetry(k.jsonPath, 50*time.Millisecond, 2*time.Second)
 	if err != nil {
 		logrus.WithError(err).WithField("path", k.jsonPath).Error("Failed to open keepalived.json")
 
@@ -150,7 +150,7 @@ func (k *KeepalivedContainerCollectorHost) StatsVrrps() (map[string]*collector.V
 		return nil, err
 	}
 
-	f, err := os.Open(k.statsPath)
+	f, err := utils.OpenFileWithRetry(k.statsPath, 50*time.Millisecond, 2*time.Second)
 	if err != nil {
 		logrus.WithError(err).WithField("path", k.statsPath).Error("Failed to open keepalived.stats")
 
@@ -169,7 +169,7 @@ func (k *KeepalivedContainerCollectorHost) DataVrrps() (map[string]*collector.VR
 		return nil, err
 	}
 
-	f, err := os.Open(k.dataPath)
+	f, err := utils.OpenFileWithRetry(k.dataPath, 50*time.Millisecond, 2*time.Second)
 	if err != nil {
 		logrus.WithError(err).WithField("path", k.dataPath).Error("Failed to open keepalived.data")
 

--- a/internal/types/host/keepalived_host_collector_host.go
+++ b/internal/types/host/keepalived_host_collector_host.go
@@ -134,6 +134,7 @@ func (k *KeepalivedHostCollectorHost) JSONVrrps() ([]collector.VRRP, error) {
 	}
 
 	fileName := "/tmp/keepalived.json"
+
 	f, err := utils.OpenFileWithRetry(fileName, 50*time.Millisecond, 2*time.Second)
 	if err != nil {
 		logrus.WithError(err).Errorf("Failed to open %v", fileName)
@@ -153,6 +154,7 @@ func (k *KeepalivedHostCollectorHost) StatsVrrps() (map[string]*collector.VRRPSt
 	}
 
 	fileName := "/tmp/keepalived.stats"
+
 	f, err := utils.OpenFileWithRetry(fileName, 50*time.Millisecond, 2*time.Second)
 	if err != nil {
 		logrus.WithError(err).Errorf("Failed to open %v", fileName)
@@ -172,6 +174,7 @@ func (k *KeepalivedHostCollectorHost) DataVrrps() (map[string]*collector.VRRPDat
 	}
 
 	fileName := "/tmp/keepalived.data"
+
 	f, err := utils.OpenFileWithRetry(fileName, 50*time.Millisecond, 2*time.Second)
 	if err != nil {
 		logrus.WithError(err).Errorf("Failed to open %v", fileName)
@@ -185,6 +188,7 @@ func (k *KeepalivedHostCollectorHost) DataVrrps() (map[string]*collector.VRRPDat
 
 func (k *KeepalivedHostCollectorHost) ScriptVrrps() ([]collector.VRRPScript, error) {
 	fileName := "/tmp/keepalived.data"
+
 	f, err := utils.OpenFileWithRetry(fileName, 50*time.Millisecond, 2*time.Second)
 	if err != nil {
 		logrus.WithError(err).Errorf("Failed to open %v", fileName)

--- a/internal/types/host/keepalived_host_collector_host.go
+++ b/internal/types/host/keepalived_host_collector_host.go
@@ -133,9 +133,10 @@ func (k *KeepalivedHostCollectorHost) JSONVrrps() ([]collector.VRRP, error) {
 		return nil, err
 	}
 
-	f, err := os.Open("/tmp/keepalived.json")
+	fileName := "/tmp/keepalived.json"
+	f, err := utils.OpenFileWithRetry(fileName, 50*time.Millisecond, 2*time.Second)
 	if err != nil {
-		logrus.WithError(err).Error("Failed to open /tmp/keepalived.json")
+		logrus.WithError(err).Errorf("Failed to open %v", fileName)
 
 		return nil, err
 	}
@@ -151,9 +152,10 @@ func (k *KeepalivedHostCollectorHost) StatsVrrps() (map[string]*collector.VRRPSt
 		return nil, err
 	}
 
-	f, err := os.Open("/tmp/keepalived.stats")
+	fileName := "/tmp/keepalived.stats"
+	f, err := utils.OpenFileWithRetry(fileName, 50*time.Millisecond, 2*time.Second)
 	if err != nil {
-		logrus.WithError(err).Error("Failed to open /tmp/keepalived.stats")
+		logrus.WithError(err).Errorf("Failed to open %v", fileName)
 
 		return nil, err
 	}
@@ -169,9 +171,10 @@ func (k *KeepalivedHostCollectorHost) DataVrrps() (map[string]*collector.VRRPDat
 		return nil, err
 	}
 
-	f, err := os.Open("/tmp/keepalived.data")
+	fileName := "/tmp/keepalived.data"
+	f, err := utils.OpenFileWithRetry(fileName, 50*time.Millisecond, 2*time.Second)
 	if err != nil {
-		logrus.WithError(err).Error("Failed to open /tmp/keepalived.data")
+		logrus.WithError(err).Errorf("Failed to open %v", fileName)
 
 		return nil, err
 	}
@@ -181,9 +184,10 @@ func (k *KeepalivedHostCollectorHost) DataVrrps() (map[string]*collector.VRRPDat
 }
 
 func (k *KeepalivedHostCollectorHost) ScriptVrrps() ([]collector.VRRPScript, error) {
-	f, err := os.Open("/tmp/keepalived.data")
+	fileName := "/tmp/keepalived.data"
+	f, err := utils.OpenFileWithRetry(fileName, 50*time.Millisecond, 2*time.Second)
 	if err != nil {
-		logrus.WithError(err).Error("Failed to open /tmp/keepalived.data")
+		logrus.WithError(err).Errorf("Failed to open %v", fileName)
 
 		return nil, err
 	}

--- a/internal/types/utils/files.go
+++ b/internal/types/utils/files.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"os"
+	"time"
+)
+
+// OpenFileWithRetry used to open a file if it didn't exist and retry until the max waiting time
+func OpenFileWithRetry(fileName string, firstTryTime, maxWaitTime time.Duration) (*os.File, error) {
+	waitTime := firstTryTime
+	startTime := time.Now()
+
+	for {
+		file, err := os.Open(fileName)
+		if err == nil {
+			return file, nil
+		}
+
+		if os.IsNotExist(err) {
+			time.Sleep(waitTime)
+
+			waitTime = waitTime * 2
+			if waitTime >= maxWaitTime/2 {
+				waitTime = maxWaitTime / 2
+			}
+		} else {
+			return nil, err
+		}
+
+		if time.Since(startTime) >= maxWaitTime {
+			return nil, os.ErrNotExist
+		}
+	}
+}

--- a/internal/types/utils/files.go
+++ b/internal/types/utils/files.go
@@ -5,30 +5,28 @@ import (
 	"time"
 )
 
-// OpenFileWithRetry used to open a file if it didn't exist and retry until the max waiting time
+// OpenFileWithRetry used to open a file if it didn't exist and retry until the max waiting time.
 func OpenFileWithRetry(fileName string, firstTryTime, maxWaitTime time.Duration) (*os.File, error) {
 	waitTime := firstTryTime
 	startTime := time.Now()
 
-	for {
+	for time.Since(startTime) < maxWaitTime {
 		file, err := os.Open(fileName)
 		if err == nil {
 			return file, nil
 		}
 
-		if os.IsNotExist(err) {
-			time.Sleep(waitTime)
-
-			waitTime = waitTime * 2
-			if waitTime >= maxWaitTime/2 {
-				waitTime = maxWaitTime / 2
-			}
-		} else {
+		if !os.IsNotExist(err) {
 			return nil, err
 		}
 
-		if time.Since(startTime) >= maxWaitTime {
-			return nil, os.ErrNotExist
+		time.Sleep(waitTime)
+
+		waitTime *= 2
+		if waitTime >= maxWaitTime/2 {
+			waitTime = maxWaitTime / 2
 		}
 	}
+
+	return nil, os.ErrNotExist
 }

--- a/internal/types/utils/files_test.go
+++ b/internal/types/utils/files_test.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestOpenFileWithRetry(t *testing.T) {
+	t.Parallel()
+
+	fileName := "/tmp/keepalived-exporter-test.txt"
+	testBody := "keepalived-exporter"
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+
+		_ = os.WriteFile(fileName, []byte(testBody), 0666)
+	}()
+
+	f, err := OpenFileWithRetry(fileName, 50*time.Millisecond, 2*time.Second)
+	if err != nil {
+	}
+	defer f.Close()
+
+	body := make([]byte, 19)
+	_, _ = f.Read(body)
+
+	_ = os.Remove(fileName)
+
+	if string(body) != testBody {
+		t.Fail()
+	}
+}

--- a/internal/types/utils/files_test.go
+++ b/internal/types/utils/files_test.go
@@ -15,18 +15,22 @@ func TestOpenFileWithRetry(t *testing.T) {
 	go func() {
 		time.Sleep(100 * time.Millisecond)
 
-		_ = os.WriteFile(fileName, []byte(testBody), 0666)
+		_ = os.WriteFile(fileName, []byte(testBody), 0o600)
 	}()
 
 	f, err := OpenFileWithRetry(fileName, 50*time.Millisecond, 2*time.Second)
 	if err != nil {
+		t.Fail()
 	}
-	defer f.Close()
+
+	defer func() {
+		_ = f.Close()
+
+		_ = os.Remove(fileName)
+	}()
 
 	body := make([]byte, 19)
 	_, _ = f.Read(body)
-
-	_ = os.Remove(fileName)
 
 	if string(body) != testBody {
 		t.Fail()


### PR DESCRIPTION
In the default wait time of 10ms, if the keepalive state has not been generated, setting the max wait time to 100ms in the PROD ENV has been met the requirements.

Here, the max waiting time for the state file is set to 2s, and the waiting time for each retry will gradually increase. If the file is not generated in the first 10ms, then wait for 50ms, 100ms, 200ms, 400ms, 800ms, and 1s sequentially. If it is not completed within the max total waiting time of 2s, the service is considered to have failed.

#85
Closes #75 