### PR TITLE
fix: add backoff to retrieve vrrp data and stats to avoid some out of sync errors

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -242,8 +242,8 @@ func (k *KeepalivedCollector) getKeepalivedStats() (*KeepalivedStats, error) {
 		if err != nil {
 			return nil, err
 		}
-		vrrpStats = result["vrrpStats"].(map[string]*VRRPStats)
-		vrrpData = result["vrrpData"].(map[string]*VRRPData)
+		vrrpStats, _ = result["vrrpStats"].(map[string]*VRRPStats)
+		vrrpData, _ = result["vrrpData"].(map[string]*VRRPData)
 
 		for instance, vData := range vrrpData {
 			if vStat, ok := vrrpStats[instance]; ok {


### PR DESCRIPTION
My proposal to fix the issue #115 .

As suggested, I added the backoff mechanisms to read stats and data files.
The synced error is steal raised if occurred after max elapsed time.


