### PR TITLE
Update to goreleaser v2

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - make dep
@@ -13,12 +14,9 @@ builds:
       - -X github.com/prometheus/common/version.Branch={{.Branch}}
       - -X github.com/prometheus/common/version.BuildDate={{.Date}}
     main: ./cmd/keepalived-exporter
-archives:
-  - name_template: "{{ .ProjectName }}-{{ .Version }}.{{ .Os }}-{{ .Arch }}"
 nfpms:
   - id: keepalived-exporter
     package_name: keepalived-exporter
-    file_name_template: "{{ .ProjectName }}-{{ .Version }}.{{ .Os }}-{{ .Arch }}"
     homepage: https://github.com/mehdy/keepalived-exporter
     maintainer: Mehdi Khoshnoodi <mehdy.khoshnoody@gmail.com>
     description: Prometheus exporter for keepalived


### PR DESCRIPTION
Thanks for writing this exporter!

- makes the goreleaser config compatible with latest release
- creates artifacts with the default naming convention (for easier integration with install scripts). This means that release artifacts will now be named slightly differently:
  ```diff
  - keepalived-exporter-1.3.3.linux-amd64.tar.gz
  + keepalived-exporter_1.3.3_linux_amd64.tar.gz
  ```