### PR TITLE
fix: export Excluded VIPs (evips) with JSON output"

### DIFF
--- a/internal/collector/collector.go
+++ b/internal/collector/collector.go
@@ -58,7 +58,7 @@ type VRRPData struct {
 	GArpDelay    int      `json:"garp_delay"`
 	VRID         int      `json:"vrid"`
 	VIPs         []string `json:"vips"`
-	ExcludedVIPs []string `json:"excluded_vips"`
+	ExcludedVIPs []string `json:"evips"`
 }
 
 // VRRPScript represents Keepalived script about VRRP.


### PR DESCRIPTION
This pull request addresses an issue with exporting excluded VIPs in JSON format.

Currently, when using JSON output, the keepalived_vrrp_excluded_state metric is missing because the excluded_vips field is absent from the Keepalived JSON output.
This fix ensures that the key, named evips, is correctly included in the JSON output, allowing the metric to be properly exported.