### PR TITLE
build: fix deprecated snapshot property for goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -35,6 +35,6 @@ dockers:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   use: github-native


### PR DESCRIPTION
name_template is renamed to version_template:
https://goreleaser.com/deprecations/#snapshotname_template