### PR TITLE
build: add kos integreation to goreleaser

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,3 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
-  - package-ecosystem: "docker"
-    directory: "/deployments/release"
-    schedule:
-      interval: "monthly"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,13 +31,20 @@ nfpms:
       - deb
       - rpm
     bindir: /usr/bin
-dockers:
-  - image_templates:
-      - mehdy/keepalived-exporter:latest
-      - mehdy/keepalived-exporter:{{ .Tag }}
-      - ghcr.io/mehdy/keepalived-exporter:latest
-      - ghcr.io/mehdy/keepalived-exporter:{{ .Tag }}
-    dockerfile: deployments/release/Dockerfile
+kos:
+  - repositories:
+      - ghcr.io/mehdy/keepalived-exporter
+      - mehdy/keepalived-exporter
+    tags:
+      - latest
+      - "{{ .Tag }}"
+    platforms:
+      - linux/arm/v6
+      - linux/arm/v7
+      - linux/arm64
+      - linux/amd64
+      - linux/386
+    base_image: alpine
 checksum:
   name_template: "checksums.txt"
 snapshot:

--- a/deployments/release/Dockerfile
+++ b/deployments/release/Dockerfile
@@ -1,5 +1,0 @@
-FROM alpine:3.21.3
-
-COPY keepalived-exporter /bin/keepalived-exporter
-
-ENTRYPOINT [ "/bin/keepalived-exporter" ]


### PR DESCRIPTION
build docker images via Ko than the native goreleaser way so we can have an easier way to build multi-arch images.

Closes: #196 