### PR TITLE
build: omit any additional to image name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,7 @@ kos:
       - linux/amd64
       - linux/386
     base_image: alpine
+    bare: true
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
Set bare to true to omit any additional like md5 to the image name cf. https://ko.build/configuration/#naming-images