### PR TITLE
Remove explict version for golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,7 +63,6 @@ jobs:
         id: go
 
       - name: Golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.1.6
           args: --timeout 3m


### PR DESCRIPTION
It's not critical to always lint with a specific version of golangci-lint.
We can go with the latest as far as we can and make changes if something breaks along the way.