### PR TITLE
feat/packaging: added systemd support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,10 +27,26 @@ nfpms:
     maintainer: Mehdi Khoshnoodi <mehdy.khoshnoody@gmail.com>
     description: Prometheus exporter for keepalived
     license: GPL-3.0
+    depends:
+      - keepalived
     formats:
       - deb
       - rpm
     bindir: /usr/bin
+    contents:
+      - src: 'packaging/systemd/keepalived-exporter.service'
+        dst: '/usr/lib/systemd/system'
+        file_info:
+          mode: 0644
+      - src: 'packaging/systemd/keepalived-exporter.sysusers'
+        dst: '/usr/lib/sysusers.d/keepalived-exporter.sysusers'
+        file_info:
+          mode: 0644
+      - src: 'packaging/systemd/keepalived-exporter'
+        dst: '/etc/conf.d/keepalived-exporter'
+        type: config|noreplace
+        file_info:
+          mode: 0644
 kos:
   - repositories:
       - ghcr.io/mehdy/keepalived-exporter

--- a/packaging/systemd/keepalived-exporter
+++ b/packaging/systemd/keepalived-exporter
@@ -1,0 +1,1 @@
+KEEPALIVED_EXPORTER_ARGS="--ka.json"

--- a/packaging/systemd/keepalived-exporter.service
+++ b/packaging/systemd/keepalived-exporter.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Prometheus Keepalived exporter
+Documentation=https://github.com/mehdy/keepalived-exporter
+Requires=network-online.target
+After=network-online.target nss-lookup.target basic.target keepalived.service
+Wants=network-online.target nss-lookup.target keepalived.service
+
+[Service]
+# Currently don't find a way to send signals to another systemd PID
+User=root
+Group=keepalived-exporter
+EnvironmentFile=-/etc/conf.d/keepalived-exporter
+ExecStart=/usr/bin/keepalived-exporter $KEEPALIVED_EXPORTER_ARGS
+ExecStop=/bin/kill -s SIGTERM $MAINPID
+ExecReload=/bin/kill -HUP $MAINPID
+NoNewPrivileges=true
+# This exporter read /tmp/keepalived.json file. Seems this file produced by keepalived itself by signal?
+PrivateTmp=false
+ProtectHome=true
+ProtectSystem=full
+ProtectHostname=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+LockPersonality=true
+RestrictRealtime=true
+RestrictNamespaces=true
+MemoryDenyWriteExecute=true
+PrivateDevices=true
+CapabilityBoundingSet=
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/keepalived-exporter.sysusers
+++ b/packaging/systemd/keepalived-exporter.sysusers
@@ -1,0 +1,1 @@
+u keepalived-exporter - "Prometheus Keepalived exporter user"


### PR DESCRIPTION
This **tested** files are from [AUR package](https://aur.archlinux.org/packages/prometheus-keepalived-exporter)

The rpm build is very limited, also can't start CI in my fork (som password required). So I don't know - can CI build this or not 🤷‍♂️

----
Resolves #201