### PR TITLE
fix exporter archive name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ rpm -i keepalived-exporter-downloaded-pkg.rpm
 ### Binary releases
 
 ```bash
-export VERSION=1.3.2
-wget https://github.com/mehdy/keepalived-exporter/releases/download/v${VERSION}/keepalived-exporter-${VERSION}.linux-amd64.tar.gz
-tar xvzf keepalived-exporter-${VERSION}.linux-amd64.tar.gz keepalived-exporter-${VERSION}.linux-amd64/keepalived-exporter
-sudo mv keepalived-exporter-${VERSION}.linux-amd64/keepalived-exporter /usr/local/bin/
+export VERSION=1.7.1
+wget https://github.com/mehdy/keepalived-exporter/releases/download/v${VERSION}/keepalived-exporter_${VERSION}_linux_amd64.tar.gz
+tar xvzf keepalived-exporter_${VERSION}_linux_amd64.tar.gz keepalived-exporter
+sudo mv keepalived-exporter /usr/local/bin/
 ```
 
 ### From source


### PR DESCRIPTION
This updates keepalived-exporter from v1.3.2 to v1.7.1.

Upstream changed the release artifact naming from dash-separated to underscore-separated (e.g. `keepalived-exporter_${VERSION}_linux_amd64.tar.gz`). The extraction step was also simplified to match the new archive structure, which now contains the binary at the top level.

Without this change, the download/extract step fails because the expected filename no longer exists.
